### PR TITLE
feat(redshift_grant): support rights in db created from datashares

### DIFF
--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -55,7 +55,7 @@ resource "redshift_grant" "public" {
 
 ### Optional
 
-- `database` (String) The name of the database to grant privileges on. Only used when `object_type` is `database`. By default, the database to which the provider is connected will be used
+- `database` (String) The name of the database to grant privileges on. By default, the database to which the provider is connected will be used
 - `group` (String) The name of the group to grant privileges on. Either `group` or `user` parameter must be set. Settings the group name to `public` or `PUBLIC` (it is case insensitive in this case) will result in a `GRANT ... TO PUBLIC` statement.
 - `objects` (Set of String) The objects upon which to grant the privileges. An empty list (the default) means to grant permissions on all objects of the specified type. Ignored when `object_type` is one of (`database`, `schema`).
 - `schema` (String) The database schema to grant privileges on.


### PR DESCRIPTION
Requires https://github.com/mmichaelb/terraform-provider-redshift/pull/223

I'm unable to read the rights granted in a db created from a datashare (so only the creation/deletion works).