### PR TITLE
feat(redshift_grant): support TRUNCATE on tables 

### DIFF
--- a/redshift/helpers.go
+++ b/redshift/helpers.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lib/pq"
 )
@@ -176,7 +176,7 @@ func validatePrivileges(privileges []string, objectType string) bool {
 			}
 		case "TABLE":
 			switch strings.ToUpper(p) {
-			case "SELECT", "UPDATE", "INSERT", "DELETE", "DROP", "REFERENCES", "RULE", "TRIGGER":
+			case "SELECT", "UPDATE", "INSERT", "DELETE", "DROP", "REFERENCES", "RULE", "TRIGGER", "TRUNCATE":
 				continue
 			default:
 				return false

--- a/redshift/helpers_test.go
+++ b/redshift/helpers_test.go
@@ -31,7 +31,7 @@ func TestValidatePrivileges(t *testing.T) {
 			expected:   true,
 		},
 		"valid list for table": {
-			privileges: []string{"insert", "update", "delete", "select", "drop", "references", "rule", "trigger"},
+			privileges: []string{"insert", "update", "delete", "select", "drop", "references", "rule", "trigger", "truncate"},
 			objectType: "table",
 			expected:   true,
 		},

--- a/redshift/resource_redshift_default_privileges_test.go
+++ b/redshift/resource_redshift_default_privileges_test.go
@@ -38,14 +38,14 @@ func TestAccRedshiftDefaultPrivileges_Basic(t *testing.T) {
 		  group = redshift_group.group.name
 		  owner = "root"
 		  object_type = "table"
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		
 		resource "redshift_default_privileges" "user" {
 		  user = redshift_user.user.name
 		  owner = "root"
 		  object_type = "table"
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		`, groupName, userName)
 		resource.Test(t, resource.TestCase{
@@ -68,6 +68,7 @@ func TestAccRedshiftDefaultPrivileges_Basic(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "truncate"),
 
 						resource.TestCheckResourceAttr("redshift_default_privileges.user", "id", fmt.Sprintf("un:%s_noschema_on:root_ot:table", userName)),
 						resource.TestCheckResourceAttr("redshift_default_privileges.user", "user", userName),
@@ -81,6 +82,7 @@ func TestAccRedshiftDefaultPrivileges_Basic(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "truncate"),
 					),
 				},
 			},
@@ -114,14 +116,14 @@ func TestAccRedshiftDefaultPrivileges_UpdateToRevoke(t *testing.T) {
 		  group = redshift_group.group.name
 		  owner = "root"
 		  object_type = "table"
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		
 		resource "redshift_default_privileges" "user" {
 		  user = redshift_user.user.name
 		  owner = "root"
 		  object_type = "table"
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		`, groupName, userName)
 
@@ -169,6 +171,7 @@ func TestAccRedshiftDefaultPrivileges_UpdateToRevoke(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "truncate"),
 
 						resource.TestCheckResourceAttr("redshift_default_privileges.user", "id", fmt.Sprintf("un:%s_noschema_on:root_ot:table", userName)),
 						resource.TestCheckResourceAttr("redshift_default_privileges.user", "user", userName),
@@ -182,6 +185,7 @@ func TestAccRedshiftDefaultPrivileges_UpdateToRevoke(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.user", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_default_privileges.group", "privileges.*", "truncate"),
 					),
 				},
 				{

--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -349,7 +349,8 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
     decode(charindex('D',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS DROP,
     decode(charindex('x',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS REFERENCES,
     decode(charindex('R',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS rule,
-    decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS TRIGGER
+    decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS TRIGGER,
+    decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'group '||u.usename), u.usename||'=', 2) ,'/',1)),NULL,0,0,0,1) AS TRUNCATE
   FROM pg_user u, pg_class cl
   JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
   WHERE
@@ -369,7 +370,8 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
     decode(charindex('D',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS DROP,
     decode(charindex('x',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS REFERENCES,
     decode(charindex('R',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS rule,
-    decode(charindex('t',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS TRIGGER
+    decode(charindex('t',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS TRIGGER,
+    decode(charindex('t',split_part(split_part(replace(array_to_string(relacl, '|'), '"', ''),'group ' || gr.groname || '=',2 ) ,'/',1)), NULL,0, 0,0, 1) AS TRUNCATE
   FROM pg_group gr, pg_class cl
   JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
   WHERE
@@ -396,7 +398,8 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 		  decode(charindex('D',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS DROP,
 		  decode(charindex('x',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS REFERENCES,
 		  decode(charindex('R',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS rule,
-		  decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS TRIGGER
+		  decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS TRIGGER,
+		  decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),NULL,0,0,0,1) AS TRUNCATE
 		FROM pg_class cl
 		JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
 		WHERE
@@ -416,9 +419,9 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 
 	for rows.Next() {
 		var objName string
-		var tableSelect, tableUpdate, tableInsert, tableDelete, tableDrop, tableReferences, tableRule, tableTrigger bool
+		var tableSelect, tableUpdate, tableInsert, tableDelete, tableDrop, tableReferences, tableRule, tableTrigger, tableTruncate bool
 
-		if err := rows.Scan(&objName, &tableSelect, &tableUpdate, &tableInsert, &tableDelete, &tableDrop, &tableReferences, &tableRule, &tableTrigger); err != nil {
+		if err := rows.Scan(&objName, &tableSelect, &tableUpdate, &tableInsert, &tableDelete, &tableDrop, &tableReferences, &tableRule, &tableTrigger, &tableTruncate); err != nil {
 			return err
 		}
 
@@ -450,6 +453,9 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 		}
 		if tableTrigger {
 			privilegesSet.Add("trigger")
+		}
+		if tableTruncate {
+			privilegesSet.Add("truncate")
 		}
 
 		if !privilegesSet.Equal(d.Get(grantPrivilegesAttr).(*schema.Set)) {

--- a/redshift/resource_redshift_grant_test.go
+++ b/redshift/resource_redshift_grant_test.go
@@ -123,7 +123,7 @@ resource "redshift_grant" "public" {
 	schema = "pg_catalog"
 	object_type = "table"
 	objects = ["pg_user_info"]
-	privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+	privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -149,6 +149,7 @@ resource "redshift_grant" "public" {
 					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "references"),
 					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "rule"),
 					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "trigger"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "truncate"),
 				),
 			},
 		},
@@ -316,7 +317,7 @@ func TestAccRedshiftGrant_BasicTable(t *testing.T) {
 		
 		  object_type = "table"
 		  objects = ["pg_user_info"]
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		
 		resource "redshift_grant" "grant_user" {
@@ -325,7 +326,7 @@ func TestAccRedshiftGrant_BasicTable(t *testing.T) {
 		
 		  object_type = "table"
 		  objects = ["pg_user_info"]
-		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+		  privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger", "truncate"]
 		}
 		`, groupName, userName)
 		resource.Test(t, resource.TestCase{
@@ -351,6 +352,7 @@ func TestAccRedshiftGrant_BasicTable(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_grant.grant", "privileges.*", "truncate"),
 
 						resource.TestCheckResourceAttr("redshift_grant.grant_user", "id", fmt.Sprintf("un:%s_ot:table_pg_catalog_pg_user_info", userName)),
 						resource.TestCheckResourceAttr("redshift_grant.grant_user", "user", userName),
@@ -367,6 +369,7 @@ func TestAccRedshiftGrant_BasicTable(t *testing.T) {
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant_user", "privileges.*", "references"),
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant_user", "privileges.*", "rule"),
 						resource.TestCheckTypeSetElemAttr("redshift_grant.grant_user", "privileges.*", "trigger"),
+						resource.TestCheckTypeSetElemAttr("redshift_grant.grant_user", "privileges.*", "truncate"),
 					),
 				},
 			},

--- a/redshift/validation.go
+++ b/redshift/validation.go
@@ -152,6 +152,7 @@ var reservedWords = []string{
 	"trailing",
 	"trigger",
 	"true",
+	"truncate",
 	"truncatecolumns",
 	"union",
 	"unique",


### PR DESCRIPTION
Hi @mmichaelb

I have a use case that entails usage of the `TRUNCATE` privilege on tables. I noticed that when attempting to provide this via your provider that it is currently unsupported and so I've endeavoured to add it. 

It's a fairly straightforward addition and the test passed locally but go isn't my strongest area so could doubtless do with checking over.